### PR TITLE
Remove mentions of Slack

### DIFF
--- a/docs/staff-docs/get-involved/index.md
+++ b/docs/staff-docs/get-involved/index.md
@@ -152,9 +152,6 @@ suggestions on this page are useful for getting started. You can always stay act
 [puppet/issues]: https://github.com/ocf/puppet/issues
 [puppet]: https://github.com/ocf/puppet
 [rt]: https://rt.ocf.berkeley.edu/
-[slack]: https://ocf.io/slack
-[slackbridge/issues]: https://github.com/ocf/slackbridge/issues
-[slackbridge]: https://github.com/ocf/slackbridge
 [sourcegraph-todo]: https://sourcegraph.ocf.berkeley.edu/search?q=TODO+case:yes
 [staffhours]: https://ocf.io/staffhours
 [utils-acct]: https://github.com/ocf/utils/tree/master/acct

--- a/docs/staff-docs/get-involved/staff-privileges.md
+++ b/docs/staff-docs/get-involved/staff-privileges.md
@@ -29,7 +29,7 @@ virtually all Directors are staffers.
 * can edit shared staff files such as `User_Info` and `motd` (message of the
   day on public servers)
 * can directly edit the OCF website and commit to some other repositories,
-  such as slackbridge, templates, and utils, and are expected to maintain them
+  such as templates and utils, and are expected to maintain them
 * must hold [[staff hours|staff-hours]], alongside other staffers
 * must join a staffer family
 

--- a/docs/staff-docs/get-involved/starter-tasks/index.md
+++ b/docs/staff-docs/get-involved/starter-tasks/index.md
@@ -13,25 +13,11 @@ staffer know you’re working on starter tasks and we will add you.
 
 These tasks don’t have to be completed in order.
 
-## Connect to the OCF IRC network
-Internet Relay Chat (IRC) is a chat protocol invented in the 80s, an early
-precursor to Slack. The OCF runs an IRC server (since 2002!), which is bridged
-to our Slack network. Many staffers prefer IRC to Slack due to its wide breadth
-of customizable clients, as opposed to Slack, which requires using their
-application.
+## Connect to OCF Chat
 
-For this task, pick an IRC client, install it on your computer, and use it to
-connect to the OCF IRC network (details at https://ocf.io/irc). Some popular
-clients are:
+OCF Chat is our where we hang out. 
 
-* Irssi (Mac/Linux, console)
-* Weechat (Max/Linux, console)
-* Hexchat (Windows/Linux, graphical)
-* Colloquy (Mac, graphical)
-
-See http://www.irchelp.org/clients/ for more recommendations.
-
-Once you’ve joined IRC, pick any channel (#rebuild, #henlo, etc) and say hi!
+See [OCF Chat](../../../user-docs/contact/chat.md) to get started. 
 
 ## Get familiar with the command line
 All of [[our servers|doc staff/backend/servers]] run Linux, and we interact with
@@ -52,7 +38,7 @@ Our chat bot is named `create` and its source code can be found at
 https://github.com/ocf/ircbot. Before testing the IRC bot right away, make sure
 you know how to use it:
 
-1. Using your IRC client (or Slack), join the #test channel.
+1. Using your IRC client, join the #test channel.
 2. Trigger some bot commands. See https://ircbot.ocf.berkeley.edu/ for a list of
    commands. For example, saying `create: thanks` will trigger a response!
 3. Find the source code for a particular command to learn how it works.

--- a/docs/staff-docs/infrastructure/prometheus.md
+++ b/docs/staff-docs/infrastructure/prometheus.md
@@ -11,7 +11,7 @@ Additionally, we don't receive email alerts for staff VMs. Monitoring for the ne
 
 Alerts can be viewed at [prometheus.ocf.berkeley.edu/alerts](https://prometheus.ocf.berkeley.edu/alerts). They are configured at [this folder][prometheus-puppet] in the Puppet configs.
 
-Alerts can additionally be configured using the [alert manager](prometheus.ocf.berkeley.edu/alertmanager). Alertmanager handles notifications for alerts via communication through email and Slack. Alerts can be inhibited or silenced. Alertmanager documentation can be found [here](https://prometheus.io/docs/alerting/alertmanager/).
+Alerts can additionally be configured using the [alert manager](prometheus.ocf.berkeley.edu/alertmanager). Alertmanager handles notifications for alerts via communication through email. Alerts can be inhibited or silenced. Alertmanager documentation can be found [here](https://prometheus.io/docs/alerting/alertmanager/).
 
 Alerts are currently under development and may not be fully comprehensive.
 

--- a/docs/staff-docs/procedures/restarting-services.md
+++ b/docs/staff-docs/procedures/restarting-services.md
@@ -15,7 +15,7 @@ Whenever a staffer restarts a production service, whether permission is
 required or not, or restarts a machine that other users have running processes
 on, they must give notice to other staffers of their actions as soon as
 possible and ideally receive acknowledgement. The staffer should preferably do
-this on Slack/Discord/Matrix/IRC.
+this on Discord/Matrix/IRC.
 
 Staffers scheduling downtime for public-facing services should make a blog post
 at [status.ocf.berkeley.edu][status] to give users sufficient advance notice.

--- a/docs/user-docs/contact/chat.md
+++ b/docs/user-docs/contact/chat.md
@@ -2,8 +2,6 @@
 title: OCF Chat
 ---
 
-TODO: write instructions for matrix, discord
-
 OCF staff often use our bridged chat server to communicate. If you have questions, feel free to
 drop by &mdash; it's often faster than emailing us, especially for
 discussion-type questions.
@@ -13,7 +11,23 @@ mostly for non-OCF-related discussion.
 
 Use whichever chat service you prefer, but keep in mind that IRC and Matrix are the coolest.
 
-## 1. Internet Relay Chat (IRC)
+## 1. Matrix
+
+With an OCF account, you'll be able to join our server!
+
+1. Go to [chat.ocf.io](https://chat.ocf.io).
+
+2. Click "Sign In"
+
+3. Click "Continue with OCF"
+
+4. Enter your OCF username and password. Do not use your Berkeley email. 
+
+5. Enjoy!
+
+You can set your username and profile picture in the settings of OCF Chat. 
+
+## 2. Internet Relay Chat (IRC)
 
 You have a couple of options for chatting over IRC:
 
@@ -57,54 +71,31 @@ your email. To see if you are registered properly, try running `/msg NickServ
 info`. You should see your email address, and where you are logged in from,
 among other results.
 
-## 2. Matrix
+## 3. Discord
 
-## 3. Slack
+If you want to NOT use open source software, you can use Discord :/
 
-1. [Create an OCF account][join] if you don't yet have one.
-
-2. Go to the [OCF Slack workspace][slack] and click the "If you have an
-   [[@ocf.berkeley.edu email address|doc services/mail]], you can create an
-   account." button.
-
-3. Enter your OCF username in the box, this should send an email to your Berkeley
-   email. If you don't recieve an email, please contact a staff member for
-   assistance.
-
-4. Click the link in your Berkeley email and follow the instructions to complete
-   setup. We *strongly* recommend setting your display name to your OCF username for
-   consistency.
-
-5. Join some channels!
-
-[join]: https://ocf.io/join
-[slack]: https://fco.slack.com
-
-## 4. Discord
+The url is: [ocf.io/discord](https://ocf.io/discord)
 
 ## Other important info
 
 ### Everything is public
 
-When using Slack, please keep in mind that the channels are connected to our
-[[IRC server|doc contact/irc]], which is open to the whole world. Anyone could
-be keeping a log of what is said, so please don't say anything that you wouldn't
+When chatting, please keep in mind that the channels are open to the whole world. 
+
+Anyone could be keeping a log of what is said, so please don't say anything that you wouldn't
 want to be public!
 
 ### I can't log in!
 
-When logging in, don't use your `@berkeley.edu` email. Instead, use [[your OCF
-email address|doc services/mail]], which is `<OCF username>@ocf.berkeley.edu`.
+When logging in to Matrix or IRC, use your OCF username. Do not use your `@berkeley.edu` email. 
+
 If you're still having trouble, you can always reset your password.
 
 ### List of Major OCF Channels
 
 *#announcements*: Low volume announcements channel. Turn on notifications for
-messages in this channel (instructions for [desktop][desktop-notifications] and
-[mobile][mobile-notifications])!
-
-[desktop-notifications]: https://slack.com/help/articles/201355156-Guide-to-desktop-notifications#channel-specific-group-dm-notifications
-[mobile-notifications]: https://slack.com/help/articles/360025446073-Guide-to-mobile-notifications#channel-specific-group-dm-notifications
+messages in this channel!
 
 *#rebuild*: Technical discussion
 
@@ -128,25 +119,3 @@ _#\*-comm_: Channels for committee discussion
 *#cs162-fa19*, *cs170-fa19*, and others: Per-class discussions
 
 *#xcf*: XCF discussion
-
-### Optional: Using wee-slack
-
-Note: This section is targeted at IRC users who would like to access Slack
-using the `weechat` IRC client.
-
-While our IRC network is bridged with Slack, some users prefer to use `weechat`
-to connect directly to Slack. We already have `weechat` installed on `tsunami`,
-so simply follow the instructions [provided by the wee-slack team][wee-slack].
-Just make sure you are in a python virtual environment before running the
-command:
-
-```bash
-python pip install websocket-client
-```
-
-We describe setting up a virtual environment [[here|doc
-services/webapps/python]].  As a general recommendation, you'll probably want
-to leave `wee-slack` running in a detached [tmux session][tmux].
-
-[wee-slack]: https://github.com/wee-slack/wee-slack
-[tmux]: https://linux.die.net/man/1/tmux

--- a/docs/user-docs/services/hpc/index.md
+++ b/docs/user-docs/services/hpc/index.md
@@ -36,7 +36,7 @@ ssh my_ocf_username@hpcctl.ocf.berkeley.edu
 If you have trouble connecting please [[contact us|doc contact]] at
 [help@ocf.berkeley.edu](mailto:help@ocf.berkeley.edu), or come to
 [[staff hours|staff-hours]] when the lab is open and chat with us in person.
-We also have a #hpc_users channel on [slack][fco] and [[irc|doc contact/irc]]
+We also have a `#hpc_users` channel on OCF chat and [[irc|doc contact/irc]]
 where you can ask questions and talk to us about anything HPC.
 
 ## The Cluster
@@ -176,7 +176,6 @@ able to interface with the GPUs.
 [staff_hours]: https://www.ocf.berkeley.edu/staff-hours
 [contact]: https://www.ocf.berkeley.edu/docs/contact/
 [venv]: https://docs.python.org/3/tutorial/venv.html
-[fco]: https://fco.slack.com/
 [mac_install]: https://singularity.lbl.gov/install-mac
 [win_install]: https://singularity.lbl.gov/install-windows
 [linux_install]: https://singularity.lbl.gov/install-linux


### PR DESCRIPTION
Goodbye slack!

See: #3.

There's one line in `staff-docs/infrastructure/kubernetes/runbooks/writing-transpirepy.md` that I didn't touch, cause it's part of the code.  

From now, we can refer to Matrix/IRC/Discord as OCF Chat. 
