### PR TITLE
Use built-in "Edit this page" link in header instead of footer button

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,3 +64,21 @@
 a:hover {
   text-decoration: underline;
 }
+
+
+.md-header__source {
+  /* hide repo button */
+  display: none;
+}
+
+.md-content__button {
+  opacity: 0.7;
+}
+
+.md-content__button svg {
+  fill: var(--md-accent-fg-color);
+}
+
+.md-content__button:hover {
+  opacity: 1;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,10 @@
 site_name: Open Computing Facility
 site_url: https://docs.ocf.berkeley.edu
+
+repo_url: https://github.com/ocf/mkdocs
+repo_name: ocf/mkdocs
+edit_uri: edit/main/docs/
+
 theme:
   name: material
   logo: assets/penguin.svg
@@ -14,6 +19,8 @@ theme:
     - search.suggest
     - search.share
     - content.code.copy
+    - content.action.edit
+    - content.action.view
   font:
     text: Roboto
     code: Meslo


### PR DESCRIPTION
#12 asks for an 'edit me' button in the footer, but I think it is better to use the theme's built-in feature instead where it appears in `<h1>`. 

I hid the repo button that gets auto generated so the header remains unchanged and styled the button so it is easier to see. 

<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/e38d9120-9c37-4201-95d7-cef27c89f3ed" />

